### PR TITLE
Update Firmware Transfer Service via YMODEM/JTAG Interface

### DIFF
--- a/boards/mpfs-icicle-kit-es/Makefile
+++ b/boards/mpfs-icicle-kit-es/Makefile
@@ -161,3 +161,4 @@ $(SOC_CONFIG_FILES): $(SOC_FPGA_DESIGN_XML_FILE)
 	$(PYTHON) tools/polarfire-soc-configuration-generator/mpfs_configuration_generator.py $< $(BINDIR)/$(BOARD_DIR)
 
 $(RISCV_TARGET): $(SOC_CONFIG_FILES)
+DIE=MPFS250T_ES

--- a/modules/compression/hss_decompress.c
+++ b/modules/compression/hss_decompress.c
@@ -71,12 +71,14 @@ int HSS_Decompress(const void* pInputBuffer, void* pOutputBuffer)
             result = mz_uncompress(
                 (void *)pOutputBuffer, &decompressedOutputSize,
                 (const void *)pByteOffset, (int)compressedImageHdr.compressedImageLen);
+            result = (result == 0) ? decompressedOutputSize : result;
         }
     }
 
     return result;
 }
 
+#ifndef CONFIG_SERVICE_YMODEM
 #include <stdlib.h>
 
 void *malloc(size_t size)
@@ -92,3 +94,4 @@ void free(void *ptr)
     mHSS_DEBUG_PRINTF(LOG_ERROR, "free() stub invoked...\n");
     (void)ptr;
 }
+#endif

--- a/tools/compression/miniz/Makefile
+++ b/tools/compression/miniz/Makefile
@@ -3,10 +3,10 @@ CC=gcc
 all: deflate dump_header deflate validate
 
 deflate: miniz.c miniz.h main.c ../../../modules/misc/hss_crc32.c
-	$(CC) -o deflate miniz.c main.c -I ../../../include ../../../modules/misc/hss_crc32.c -I../../../ -I../../../thirdparty/opensbi/include/ -D__riscv_xlen=64
+	$(CC) -o deflate miniz.c main.c -I/home/unikie/Desktop/polarfire/hss/work/clean/hart-software-services/build/boards/mpfs-icicle-kit-es/fpga_design_config/ -I /home/unikie/Desktop/polarfire/hss/work/clean/hart-software-services/thirdparty/opensbi/include -I ../../../include ../../../modules/misc/hss_crc32.c -I../../../ -I../../../thirdparty/opensbi/include/-I -D__riscv_xlen=64
 
 dump_header: dump_header.c
-	$(CC) -o dump_header dump_header.c
+	$(CC) -o dump_header dump_header.c -I /home/unikie/Desktop/polarfire/hss/work/clean/hart-software-services/thirdparty/opensbi/include
 
 validate: validate.c
 	$(CC) -g -o validate validate.c miniz.c

--- a/tools/compression/miniz/dump_header.c
+++ b/tools/compression/miniz/dump_header.c
@@ -6,6 +6,8 @@
 
 int main(int argc, char **argv)
 {
+  int i;
+
 	if (argc != 2) {
 		fprintf(stderr, "Usage: %s <input>\n\n", argv[0]);
 		exit(-1);
@@ -49,8 +51,17 @@ int main(int argc, char **argv)
 	printf("offsetof(originalCrc):		%lu\n", offsetof(struct HSS_CompressedImage, originalCrc));
 	printf("offsetof(compressedImageLen):	%lu\n", offsetof(struct HSS_CompressedImage, compressedImageLen));
 	printf("offsetof(originalImageLen):	%lu\n", offsetof(struct HSS_CompressedImage, originalImageLen));
+#if 0
 	printf("offsetof(hash):			%lu\n", offsetof(struct HSS_CompressedImage, hash));
 	printf("offsetof(ecdsaSig):		%lu\n", offsetof(struct HSS_CompressedImage, ecdsaSig));
+#else
+  for (i=0; i<32; i++)
+    printf("offsetof(pad1[%d]):			0x%02X(%c)\n",
+        i, (unsigned int)offsetof(struct HSS_CompressedImage, pad1[i]), (char)offsetof(struct HSS_CompressedImage, pad1[i]));
+  for (i=0; i<32; i++)
+    printf("offsetof(pad2[%d]):			0x%02X(%c)\n",
+        i, (unsigned int)offsetof(struct HSS_CompressedImage, pad2[i]), (char)offsetof(struct HSS_CompressedImage, pad2[i]));
+#endif
 
 	printf("Magic:				0x%08X (expected 0x%08X)\n", imgHdr.magic, mHSS_COMPRESSED_MAGIC);
 	printf("Version:			0x%08X (expected 0x%08X)\n", imgHdr.version,

--- a/tools/compression/miniz/main.c
+++ b/tools/compression/miniz/main.c
@@ -10,6 +10,7 @@
 #include "hss_types.h"
 #include "hss_crc32.h"
 
+#define mHSS_COMPRESSED_VERSION_MINIZ 2u
 
 int main(int argc, char **argv)
 {

--- a/tools/compression/miniz/miniz.h
+++ b/tools/compression/miniz/miniz.h
@@ -526,9 +526,15 @@ typedef struct mz_dummy_time_t_tag
 #define MZ_FREE(x) (void)x, ((void)0)
 #define MZ_REALLOC(p, x) NULL
 #else
+#if 0
 #define MZ_MALLOC(x) my_malloc(x)
 #define MZ_FREE(x) my_free(x)
 #define MZ_REALLOC(p, x) realloc(p, x)
+#else
+#define MZ_MALLOC(x) malloc(x)
+#define MZ_FREE(x) free(x)
+#define MZ_REALLOC(p, x) realloc(p, x)
+#endif
 #endif
 
 #define MZ_MAX(a, b) (((a) > (b)) ? (a) : (b))

--- a/tools/compression/miniz/validate.c
+++ b/tools/compression/miniz/validate.c
@@ -5,6 +5,7 @@
 #include "../../../include/hss_types.h"
 #include "miniz.h"
 
+#define mHSS_COMPRESSED_VERSION_MINIZ  2u
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
# Description

For firmware transfer on NAVC and DPU board, this function is added because there is no USB OTG interface.
To overcome that limitation, YMODEM and JTAG interface is used for transferring binary from host pc to target board.
Also, compression and decompression method are added to reduced transfer binary size.

## Type of change

- [O ] New feature (non-breaking change which adds functionality)

